### PR TITLE
updated plausible analytics to use v2 version for fetching stats

### DIFF
--- a/template/app/src/analytics/providers/plausibleAnalyticsUtils.ts
+++ b/template/app/src/analytics/providers/plausibleAnalyticsUtils.ts
@@ -34,23 +34,69 @@ export async function getDailyPageViews() {
   };
 }
 
-async function getTotalPageViews() {
-  const response = await fetch(
-    `${PLAUSIBLE_BASE_URL}/v1/stats/aggregate?site_id=${PLAUSIBLE_SITE_ID}&metrics=pageviews`,
-    {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${PLAUSIBLE_API_KEY}`,
-      },
-    }
-  );
+/**
+ * Fetches total page views using Plausible's v2 Stats API.
+ */
+export async function getTotalPageViews() {
+  const url = `${process.env.PLAUSIBLE_BASE_URL}/api/v2/query`;
+  
+  // Construct the payload. In this example, we're asking for total "pageviews"
+  // for the entire period (you can adjust the date_range as needed).
+  const payload = {
+    site_id: process.env.PLAUSIBLE_SITE_ID,
+    metrics: ["pageviews"],
+    date_range: "all"  // or "7d", "30d", etc.
+  };
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${process.env.PLAUSIBLE_API_KEY}`,
+    },
+    body: JSON.stringify(payload)
+  });
+
   if (!response.ok) {
     throw new Error(`HTTP error! Status: ${response.status}`);
   }
-  const json = (await response.json()) as PageViewsResult;
 
-  return json.results.pageviews.value;
+  const json = await response.json();
+  // Assuming that the API returns a single row of results (an array with one element),
+  // and that the "pageviews" metric is the first in the metrics array:
+  const totalPageviews = json.results[0]?.metrics[0];
+  return totalPageviews;
+}
+
+/**
+ * Fetches pageviews for a specific day.
+ */
+export async function getPageviewsForDate(date: string) {
+  const url = `${process.env.PLAUSIBLE_BASE_URL}/api/v2/query`;
+  
+  // When querying for a specific date, use a custom date range with the same start and end dates.
+  const payload = {
+    site_id: process.env.PLAUSIBLE_SITE_ID,
+    metrics: ["pageviews"],
+    date_range: [date, date]
+  };
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${process.env.PLAUSIBLE_API_KEY}`,
+    },
+    body: JSON.stringify(payload)
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP error! Status: ${response.status}`);
+  }
+  
+  const json = await response.json();
+  // Extract the pageviews from the returned results.
+  return json.results[0]?.metrics[0] || 0;
 }
 
 async function getPrevDayViewsChangePercent() {
@@ -77,19 +123,6 @@ async function getPrevDayViewsChangePercent() {
     change = ((pageViewsYesterday - pageViewsDayBeforeYesterday) / pageViewsDayBeforeYesterday) * 100;
   }
   return change.toFixed(0);
-}
-
-async function getPageviewsForDate(date: string) {
-  const url = `${PLAUSIBLE_BASE_URL}/v1/stats/aggregate?site_id=${PLAUSIBLE_SITE_ID}&period=day&date=${date}&metrics=pageviews`;
-  const response = await fetch(url, {
-    method: 'GET',
-    headers: headers,
-  });
-  if (!response.ok) {
-    throw new Error(`HTTP error! Status: ${response.status}`);
-  }
-  const data = (await response.json()) as PageViewsResult;
-  return data.results.pageviews.value;
 }
 
 export async function getSources() {


### PR DESCRIPTION
Used v2 version for fetching stats as v1 was giving 404 error. Tried and tested myself.

## Description

> Describe your PR! If it fixes specific issue, mention it with "Fixes # (issue)".

## Contributor Checklist

> Make sure to do the following steps if they are applicable to your PR:

- [ ] **Update e2e tests**: If you changed the [/template/app](/template/app), then make sure to do any neccessary updates to [/template/e2e-tests](/template/e2e-tests) also.
- [ ] **Update demo app**: If you changed the [/template/app](/template/app), then make sure to do any neccessary updates to [/opensaas-sh/app_diff](/opensaas-sh/app_diff) also. Check [/opensaas-sh/README.md](/opensaas-sh/README.md) for details.
- [ ] **Update docs**: If needed, update the [/opensaas-sh/blog/src/content/docs](/opensaas-sh/blog/src/content/docs).
