### PR TITLE
Update .env.server.example

### DIFF
--- a/template/app/.env.server.example
+++ b/template/app/.env.server.example
@@ -40,7 +40,7 @@ OPENAI_API_KEY=sk-k...
 PLAUSIBLE_API_KEY=gUTgtB...
 # You will find your site id in the Plausible dashboard. It will look like 'opensaas.sh'
 PLAUSIBLE_SITE_ID=yoursite.com
-PLAUSIBLE_BASE_URL=https://plausible.io/settings/api-keys # if you are self-hosting plausible, change this to your plausible instance's base url
+PLAUSIBLE_BASE_URL=https://plausible.io/settings/api-keys # if you are self-hosting plausible, change this to your plausible instance's base url and don't forget to add /api at the end i.e analytics.yoursite.com/api
 
 # (OPTIONAL) get your google service account key at https://console.cloud.google.com/iam-admin/serviceaccounts
 GOOGLE_ANALYTICS_CLIENT_EMAIL=email@example.gserviceaccount.com


### PR DESCRIPTION
When using self hosted Plausible instance /api is necessary at the end of Base URL.

## Description

> When using self hosted Plausible instance "/api" is necessary at the end of Base URL.